### PR TITLE
Dotnet version change for GitHub actions, correct one

### DIFF
--- a/.github/workflows/Running Tests.yaml
+++ b/.github/workflows/Running Tests.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Setup dotnet 3.1.x
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: '3.1.0'
+          dotnet-version: '3.1'
       - name: Install dependencies
         run: dotnet restore
       - name: Build the project


### PR DESCRIPTION
# Motivation
Changing the dotnet version that the GitHub workflow needs, to the correct version.
On the "main" branch, the correct version was not specified.
My experience with CI/CD stems mostly from Gitlab's system, so trial and error is expected.

## Improvements for next time
* Only allow pushes to "main" via Pull Requests.
* Experiment with GitHub Actions in a feature branch.