### PR TITLE
Different method for selecting media & adding wav support

### DIFF
--- a/BusinessLogicLayer/AudioLogic.cs
+++ b/BusinessLogicLayer/AudioLogic.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace BusinessLogicLayer
 {
@@ -17,24 +18,26 @@ namespace BusinessLogicLayer
             this.selectedFiles = selectedFiles;
         }
 
-        //TODO: add ability for more media filetypes, other than mp4.
-        public override void CreateFilename()
+        //TODO: convert to different audio files, other than mp3.
+        public override void CreateNewFilename()
         {
             foreach (var item in this.selectedFiles)
             {
-                audioFilename.Add(item.Replace(".mp4", ".mp3"));
+                int index = item.IndexOf(".");
+                string filename = item.Substring(0, index) + ".mp3";
+                audioFilename.Add(filename);
             }
         }
 
-        public void ExtractAudio()
+        public override void CreateNewFile()
         {
-            CreateFilename();
+            Process process = new Process();
+            process.StartInfo.FileName = "ffmpeg.exe";
 
             for (int i = 0; i < this.selectedFiles.Length; i++)
             {
-                //TODO: change to a safer method to add arguments to a commandline application.
-                string command = @"/C ffmpeg -i " + "\"" + this.selectedFiles[i] + "\"" + " " + "\"" + this.audioFilename[i] + "\"";
-                Process process = Process.Start("CMD.exe", command);
+                process.StartInfo.Arguments = String.Format(@"-i ""{0}"" ""{1}""", this.selectedFiles[i], this.audioFilename[i]);
+                process.Start();
                 process.WaitForExit();
             }
         }

--- a/BusinessLogicLayer/AudioLogic.cs
+++ b/BusinessLogicLayer/AudioLogic.cs
@@ -7,13 +7,13 @@ namespace BusinessLogicLayer
 {
     public class AudioLogic : FileHandling
     {
-        private string[] selectedFiles;
+        private List<string> selectedFiles = new List<string>();
         private List<string> audioFiles = new List<string>();
 
-        public string[] SelectedFiles { get { return this.selectedFiles; } set { this.selectedFiles = value; } }
+        public List<string> SelectedFiles { get { return this.selectedFiles; } set { this.selectedFiles = value; } }
         public List<string> AudioFiles { get { return this.audioFiles; } set { this.audioFiles = value; } }
 
-        public AudioLogic(string[] selectedFiles)
+        public AudioLogic(List<string> selectedFiles)
         {
             this.selectedFiles = selectedFiles;
         }
@@ -42,7 +42,7 @@ namespace BusinessLogicLayer
             Process process = new Process();
             process.StartInfo.FileName = "ffmpeg.exe";
 
-            for (int i = 0; i < this.selectedFiles.Length; i++)
+            for (int i = 0; i < this.selectedFiles.Count; i++)
             {
                 process.StartInfo.Arguments = String.Format(@"-i ""{0}"" ""{1}""", this.selectedFiles[i], this.audioFiles[i]);
                 process.Start();

--- a/BusinessLogicLayer/AudioLogic.cs
+++ b/BusinessLogicLayer/AudioLogic.cs
@@ -8,10 +8,10 @@ namespace BusinessLogicLayer
     public class AudioLogic : FileHandling
     {
         private string[] selectedFiles;
-        private List<string> audioFilename = new List<string>();
+        private List<string> audioFiles = new List<string>();
 
         public string[] SelectedFiles { get { return this.selectedFiles; } set { this.selectedFiles = value; } }
-        public List<string> AudioFilename { get { return this.audioFilename; } set { this.audioFilename = value; } }
+        public List<string> AudioFiles { get { return this.audioFiles; } set { this.audioFiles = value; } }
 
         public AudioLogic(string[] selectedFiles)
         {
@@ -19,13 +19,21 @@ namespace BusinessLogicLayer
         }
 
         //TODO: convert to different audio files, other than mp3.
-        public override void CreateNewFilename()
+        public override void ChangeFiletype(string newFiletype)
         {
             foreach (var item in this.selectedFiles)
             {
-                int index = item.IndexOf(".");
-                string filename = item.Substring(0, index) + ".mp3";
-                audioFilename.Add(filename);
+                int dotIndex = item.IndexOf(".");
+                string filename = item.Substring(0, dotIndex);
+                if (newFiletype == "wav")
+                {
+                    filename += ".wav";
+                }
+                else if (newFiletype == "mp3")
+                {
+                    filename += ".mp3";
+                }
+                audioFiles.Add(filename);
             }
         }
 
@@ -36,7 +44,7 @@ namespace BusinessLogicLayer
 
             for (int i = 0; i < this.selectedFiles.Length; i++)
             {
-                process.StartInfo.Arguments = String.Format(@"-i ""{0}"" ""{1}""", this.selectedFiles[i], this.audioFilename[i]);
+                process.StartInfo.Arguments = String.Format(@"-i ""{0}"" ""{1}""", this.selectedFiles[i], this.audioFiles[i]);
                 process.Start();
                 process.WaitForExit();
             }

--- a/BusinessLogicLayer/FileHandling.cs
+++ b/BusinessLogicLayer/FileHandling.cs
@@ -6,6 +6,8 @@ namespace BusinessLogicLayer
 {
     public abstract class FileHandling
     {
-        public abstract void CreateFilename();
+        public abstract void CreateNewFilename();
+
+        public abstract void CreateNewFile();
     }
 }

--- a/BusinessLogicLayer/FileHandling.cs
+++ b/BusinessLogicLayer/FileHandling.cs
@@ -6,7 +6,7 @@ namespace BusinessLogicLayer
 {
     public abstract class FileHandling
     {
-        public abstract void CreateNewFilename();
+        public abstract void ChangeFiletype(string currentFiletype);
 
         public abstract void CreateNewFile();
     }

--- a/MediaManager/MediaManager.Designer.cs
+++ b/MediaManager/MediaManager.Designer.cs
@@ -33,6 +33,8 @@
             this.filesListView = new System.Windows.Forms.ListView();
             this.label1 = new System.Windows.Forms.Label();
             this.clearListBT = new System.Windows.Forms.Button();
+            this.audioCB = new System.Windows.Forms.ComboBox();
+            this.label2 = new System.Windows.Forms.Label();
             this.SuspendLayout();
             // 
             // selectFolderBT
@@ -51,11 +53,11 @@
             // 
             this.extractAudioBT.BackColor = System.Drawing.Color.Lime;
             this.extractAudioBT.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.extractAudioBT.Location = new System.Drawing.Point(162, 31);
+            this.extractAudioBT.Location = new System.Drawing.Point(677, 52);
             this.extractAudioBT.Name = "extractAudioBT";
-            this.extractAudioBT.Size = new System.Drawing.Size(130, 29);
+            this.extractAudioBT.Size = new System.Drawing.Size(92, 23);
             this.extractAudioBT.TabIndex = 1;
-            this.extractAudioBT.Text = "Extract audio to mp3";
+            this.extractAudioBT.Text = "Extract audio";
             this.extractAudioBT.UseVisualStyleBackColor = false;
             this.extractAudioBT.Click += new System.EventHandler(this.extractAudioBT_Click);
             // 
@@ -92,11 +94,33 @@
             this.clearListBT.UseVisualStyleBackColor = false;
             this.clearListBT.Click += new System.EventHandler(this.clearListBT_Click);
             // 
+            // audioCB
+            // 
+            this.audioCB.FormattingEnabled = true;
+            this.audioCB.Items.AddRange(new object[] {
+            "wav",
+            "mp3"});
+            this.audioCB.Location = new System.Drawing.Point(531, 52);
+            this.audioCB.Name = "audioCB";
+            this.audioCB.Size = new System.Drawing.Size(106, 23);
+            this.audioCB.TabIndex = 5;
+            // 
+            // label2
+            // 
+            this.label2.AutoSize = true;
+            this.label2.Location = new System.Drawing.Point(531, 34);
+            this.label2.Name = "label2";
+            this.label2.Size = new System.Drawing.Size(106, 15);
+            this.label2.TabIndex = 6;
+            this.label2.Text = "Choose audio type";
+            // 
             // MediaManager
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(800, 450);
+            this.Controls.Add(this.label2);
+            this.Controls.Add(this.audioCB);
             this.Controls.Add(this.clearListBT);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.filesListView);
@@ -116,6 +140,8 @@
         private System.Windows.Forms.ListView filesListView;
         private System.Windows.Forms.Label label1;
         private System.Windows.Forms.Button clearListBT;
+        private System.Windows.Forms.ComboBox audioCB;
+        private System.Windows.Forms.Label label2;
     }
 }
 

--- a/MediaManager/MediaManager.Designer.cs
+++ b/MediaManager/MediaManager.Designer.cs
@@ -51,11 +51,11 @@
             // 
             this.extractAudioBT.BackColor = System.Drawing.Color.Lime;
             this.extractAudioBT.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
-            this.extractAudioBT.Location = new System.Drawing.Point(169, 34);
+            this.extractAudioBT.Location = new System.Drawing.Point(162, 31);
             this.extractAudioBT.Name = "extractAudioBT";
-            this.extractAudioBT.Size = new System.Drawing.Size(93, 23);
+            this.extractAudioBT.Size = new System.Drawing.Size(130, 29);
             this.extractAudioBT.TabIndex = 1;
-            this.extractAudioBT.Text = "Extract audio";
+            this.extractAudioBT.Text = "Extract audio to mp3";
             this.extractAudioBT.UseVisualStyleBackColor = false;
             this.extractAudioBT.Click += new System.EventHandler(this.extractAudioBT_Click);
             // 
@@ -75,9 +75,9 @@
             this.label1.Font = new System.Drawing.Font("Segoe UI", 11.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
             this.label1.Location = new System.Drawing.Point(12, 222);
             this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(103, 20);
+            this.label1.Size = new System.Drawing.Size(115, 20);
             this.label1.TabIndex = 3;
-            this.label1.Text = "Matched files";
+            this.label1.Text = "Matched file(s)";
             // 
             // clearListBT
             // 

--- a/MediaManager/MediaManager.cs
+++ b/MediaManager/MediaManager.cs
@@ -66,12 +66,13 @@ namespace MediaManager
         {
             if (filesListView.Items.Count == 0)
             {
-                MessageBox.Show("No folder selected.");
+                MessageBox.Show("No files selected.");
             }
             else
             {
                 AudioLogic audioLogic = new AudioLogic(filePaths);
-                audioLogic.ExtractAudio();
+                audioLogic.CreateNewFilename();
+                audioLogic.CreateNewFile();
 
                 ClearFileList();
                 MessageBox.Show("Audio extracted");

--- a/MediaManager/MediaManager.cs
+++ b/MediaManager/MediaManager.cs
@@ -32,7 +32,7 @@ namespace MediaManager
 
         private void extractAudioBT_Click(object sender, EventArgs e)
         {
-            ExtractAudio();
+            ExtractAudio(audioCB.GetItemText(audioCB.SelectedItem));
         }
 
         private void clearListBT_Click(object sender, EventArgs e)
@@ -62,16 +62,20 @@ namespace MediaManager
             }
         }
 
-        public void ExtractAudio()
+        public void ExtractAudio(string type)
         {
             if (filesListView.Items.Count == 0)
             {
                 MessageBox.Show("No files selected.");
             }
+            else if(audioCB.SelectedIndex < 0)
+            {
+                MessageBox.Show("No audio type selected.");
+            }
             else
             {
                 AudioLogic audioLogic = new AudioLogic(filePaths);
-                audioLogic.CreateNewFilename();
+                audioLogic.ChangeFiletype(type);
                 audioLogic.CreateNewFile();
 
                 ClearFileList();

--- a/MediaManager/MediaManager.cs
+++ b/MediaManager/MediaManager.cs
@@ -14,10 +14,10 @@ namespace MediaManager
 {
     public partial class MediaManager : Form
     {
-        string[] filePaths;
+        List<string> filePaths = new List<string>();
         List<string> fileNames = new List<string>();
 
-        FolderBrowserDialog folderBrowser = new FolderBrowserDialog();
+        OpenFileDialog fileDialog = new OpenFileDialog();
 
         public MediaManager()
         {
@@ -26,8 +26,8 @@ namespace MediaManager
 
         private void selectFolderBT_Click(object sender, EventArgs e)
         {
-            GetFileDetails();
-            ShowFiles();
+            GetSelectedFile();
+            ShowFileName();
         }
 
         private void extractAudioBT_Click(object sender, EventArgs e)
@@ -40,21 +40,27 @@ namespace MediaManager
             ClearFileList();
         }
 
-        //TODO: add ability to detect more media filetypes, other than mp4.
-        public void GetFileDetails()
+        //TODO: add ability to detect more media filetypes.
+        public void GetSelectedFile()
         {
-            if (folderBrowser.ShowDialog() == DialogResult.OK && !string.IsNullOrWhiteSpace(folderBrowser.SelectedPath))
+            fileDialog.Filter = "All Media Files|*.wav;*.mp3;*.avi;*.mov;*.mp4;*.WAV;*.MP3;*.AVI;*.MOV;*.MP4;";
+            fileDialog.Multiselect = true;
+
+            if (fileDialog.ShowDialog() == DialogResult.OK)
             {
-                filePaths = Directory.GetFiles(folderBrowser.SelectedPath, "*.mp4");
+                if (fileDialog.FileNames.Length != 0)
+                {
+                    filePaths = fileDialog.FileNames.ToList();
+                }
 
                 foreach (var item in filePaths)
                 {
-                    fileNames.Add(item.Replace(folderBrowser.SelectedPath, String.Empty).Replace(@"\", "")); //Only display the filenames.
+                    fileNames = fileDialog.SafeFileNames.ToList(); //Storing only the filenames, not the full path.
                 }
             }
         }
 
-        private void ShowFiles()
+        private void ShowFileName()
         {
             foreach (var item in fileNames)
             {
@@ -85,7 +91,7 @@ namespace MediaManager
 
         public void ClearFileList()
         {
-            Array.Clear(filePaths, 0, filePaths.Length);
+            filePaths.Clear();
             fileNames.Clear();
             filesListView.Items.Clear();
         }

--- a/MediaManagerTest/AudioLogicTest.cs
+++ b/MediaManagerTest/AudioLogicTest.cs
@@ -21,7 +21,7 @@ namespace MediaManagerTest
 
             // act
             before = audioLogic.AudioFilename.Count;
-            audioLogic.CreateFilename();
+            audioLogic.CreateNewFilename();
             after = audioLogic.AudioFilename.Count;
             audioFiles = audioLogic.AudioFilename;
 

--- a/MediaManagerTest/AudioLogicTest.cs
+++ b/MediaManagerTest/AudioLogicTest.cs
@@ -16,8 +16,8 @@ namespace MediaManagerTest
         {
             // arrange
             List<string> audioFiles = new List<string>();
-            string[] files = new string[] { "1.mp4", "2.mp4" };
-            audioLogic = new AudioLogic(files);
+            List<string> selectedFiles = new List<string>() { "1.mp4", "2.mp4" };
+            audioLogic = new AudioLogic(selectedFiles);
 
             // act
             before = audioLogic.AudioFiles.Count;
@@ -36,8 +36,8 @@ namespace MediaManagerTest
         {
             // arrange
             List<string> audioFiles = new List<string>();
-            string[] files = new string[] { "test1.mp4", "test2.mp4" };
-            audioLogic = new AudioLogic(files);
+            List<string> selectedFiles = new List<string>() { "test1.mp4", "test2.mp4" };
+            audioLogic = new AudioLogic(selectedFiles);
 
             // act
             before = audioLogic.AudioFiles.Count;

--- a/MediaManagerTest/AudioLogicTest.cs
+++ b/MediaManagerTest/AudioLogicTest.cs
@@ -12,7 +12,7 @@ namespace MediaManagerTest
         int after;
 
         [TestMethod]
-        public void GettingTwoAudioFiles()
+        public void ChangeToWAVType()
         {
             // arrange
             List<string> audioFiles = new List<string>();
@@ -20,15 +20,35 @@ namespace MediaManagerTest
             audioLogic = new AudioLogic(files);
 
             // act
-            before = audioLogic.AudioFilename.Count;
-            audioLogic.CreateNewFilename();
-            after = audioLogic.AudioFilename.Count;
-            audioFiles = audioLogic.AudioFilename;
+            before = audioLogic.AudioFiles.Count;
+            audioLogic.ChangeFiletype("wav");
+            after = audioLogic.AudioFiles.Count;
+            audioFiles = audioLogic.AudioFiles;
 
             // assert
             Assert.AreEqual(0, before);
             Assert.AreEqual(2, after);
-            Assert.AreEqual("1.mp3", audioFiles[0]);
+            Assert.AreEqual("1.wav", audioFiles[0]);
+        }
+
+        [TestMethod]
+        public void ChangeToMP3Type()
+        {
+            // arrange
+            List<string> audioFiles = new List<string>();
+            string[] files = new string[] { "test1.mp4", "test2.mp4" };
+            audioLogic = new AudioLogic(files);
+
+            // act
+            before = audioLogic.AudioFiles.Count;
+            audioLogic.ChangeFiletype("mp3");
+            after = audioLogic.AudioFiles.Count;
+            audioFiles = audioLogic.AudioFiles;
+
+            // assert
+            Assert.AreEqual(0, before);
+            Assert.AreEqual(2, after);
+            Assert.AreEqual("test2.mp3", audioFiles[1]);
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,12 @@ The application makes use of FFmpeg to perform the conversion work.
 
 ---
 
-## Limitations (as of 29-4-2021)
-* The application can only detect mp4 files in the source directory.
-* The application can only convert to mp3 files.
+## Limitations (as of 1-5-2021)
+* The application can only detect the following files to convert:
+    * wav & WAV
+    * mp3 & MP3
+    * avi & AVI
+    * mov & MOV
+    * mp4 & MP4
+* The application can only convert to mp3 or wav files.
 * The application does not automatically download a copy of FFmpeg.


### PR DESCRIPTION
# Overview

Instead of **only** selecting a folder and selecting .mp4 files from it, the program now allows you to select a **couple** of media files from a folder.
Supported list:
    * wav & WAV
    * mp3 & MP3
    * avi & AVI
    * mov & MOV
    * mp4 & MP4

The program can now, besides mp3, also create wav files.

## Point to consider for new versions
* Adding support for more media types.
* Creating more types of audio files.
* Converting video files from one type to another.