### PR TITLE
Change: clearing the audio type list

### DIFF
--- a/MediaManager/MediaManager.cs
+++ b/MediaManager/MediaManager.cs
@@ -80,7 +80,7 @@ namespace MediaManager
                 audioFileHandling.CreateNewFile();
 
                 ClearFileList();
-                MessageBox.Show("Audio extracted");
+                MessageBox.Show("Audio extracted.");
             }
         }
 
@@ -104,6 +104,7 @@ namespace MediaManager
             filePaths.Clear();
             fileNames.Clear();
             filesListView.Items.Clear();
+            selectedAudioTypes.Clear();
         }
     }
 }


### PR DESCRIPTION
The list of selected audiotypes was not being cleared after a
converting process.
This problem is now solved.