### PR TITLE
Change: type of the "FileHandling" class

### DIFF
--- a/BusinessLogicLayer/Audio/AudioFileHandling.cs
+++ b/BusinessLogicLayer/Audio/AudioFileHandling.cs
@@ -20,7 +20,7 @@ namespace BusinessLogicLayer.Audio
             this.selectedAudioTypes = selectedAudioTypes;
         }
 
-        public override void ChangeFiletype()
+        public void ChangeFiletype()
         {
             foreach (var filePath in this.selectedFilePaths)
             {
@@ -34,7 +34,7 @@ namespace BusinessLogicLayer.Audio
             }
         }
 
-        public override void CreateNewFile()
+        public void CreateNewFile()
         {
             Process process = new Process();
             process.StartInfo.FileName = "ffmpeg.exe";

--- a/BusinessLogicLayer/FileHandling.cs
+++ b/BusinessLogicLayer/FileHandling.cs
@@ -4,10 +4,10 @@ using System.Text;
 
 namespace BusinessLogicLayer
 {
-    public abstract class FileHandling
+    public interface FileHandling
     {
-        public abstract void ChangeFiletype();
+        void ChangeFiletype();
 
-        public abstract void CreateNewFile();
+        void CreateNewFile();
     }
 }

--- a/MediaManagerTest/AudioLogicTest.cs
+++ b/MediaManagerTest/AudioLogicTest.cs
@@ -9,8 +9,8 @@ namespace MediaManagerTest
     {
         AudioFileHandling audioFileHandling;
         private List<AudioType> selectedAudioTypes = new List<AudioType>();
-        int before;
-        int after;
+        int audioAmountBeforeConversion;
+        int audioAmountAfterConversion;
 
         [TestMethod]
         public void ChangeToWAVType()
@@ -22,14 +22,14 @@ namespace MediaManagerTest
             audioFileHandling = new AudioFileHandling(selectedFilePaths, selectedAudioTypes);
 
             // act
-            before = audioFileHandling.AudioFiles.Count;
+            audioAmountBeforeConversion = audioFileHandling.AudioFiles.Count;
             audioFileHandling.ChangeFiletype();
-            after = audioFileHandling.AudioFiles.Count;
+            audioAmountAfterConversion = audioFileHandling.AudioFiles.Count;
             audioFiles = audioFileHandling.AudioFiles;
 
             // assert
-            Assert.AreEqual(0, before);
-            Assert.AreEqual(2, after);
+            Assert.AreEqual(0, audioAmountBeforeConversion);
+            Assert.AreEqual(2, audioAmountAfterConversion);
             Assert.AreEqual(@"C:\tmp\1.wav", audioFiles[0]);
         }
 
@@ -43,14 +43,14 @@ namespace MediaManagerTest
             audioFileHandling = new AudioFileHandling(selectedFilePaths, selectedAudioTypes);
 
             // act
-            before = audioFileHandling.AudioFiles.Count;
+            audioAmountBeforeConversion = audioFileHandling.AudioFiles.Count;
             audioFileHandling.ChangeFiletype();
-            after = audioFileHandling.AudioFiles.Count;
+            audioAmountAfterConversion = audioFileHandling.AudioFiles.Count;
             audioFiles = audioFileHandling.AudioFiles;
 
             // assert
-            Assert.AreEqual(0, before);
-            Assert.AreEqual(2, after);
+            Assert.AreEqual(0, audioAmountBeforeConversion);
+            Assert.AreEqual(2, audioAmountAfterConversion);
             Assert.AreEqual("C:\tmp\test2.mp3", audioFiles[1]);
         }
     }


### PR DESCRIPTION
* Changed the class type from 'abstract' to 'interface'.
* Reason being that the implementation of the methods can vary for
different media files.