### PR TITLE
Change: naming of interfaces for consistency

### DIFF
--- a/BusinessLogicLayer/Audio/AudioFileHandling.cs
+++ b/BusinessLogicLayer/Audio/AudioFileHandling.cs
@@ -4,17 +4,17 @@ using System.Diagnostics;
 
 namespace BusinessLogicLayer.Audio
 {
-    public class AudioFileHandling : FileHandling
+    public class AudioFileHandling : IFileHandling
     {
-        private List<AudioType> selectedAudioTypes = new List<AudioType>();
+        private List<IAudioType> selectedAudioTypes = new List<IAudioType>();
         private List<string> selectedFilePaths = new List<string>();
         private List<string> audioFiles = new List<string>();
 
         public List<string> SelectedFiles { get { return this.selectedFilePaths; } set { this.selectedFilePaths = value; } }
         public List<string> AudioFiles { get { return this.audioFiles; } set { this.audioFiles = value; } }
-        public List<AudioType> AudioTypes { get { return this.selectedAudioTypes; } set { this.selectedAudioTypes = value; } }
+        public List<IAudioType> AudioTypes { get { return this.selectedAudioTypes; } set { this.selectedAudioTypes = value; } }
 
-        public AudioFileHandling(List<string> selectedFilePaths, List<AudioType> selectedAudioTypes)
+        public AudioFileHandling(List<string> selectedFilePaths, List<IAudioType> selectedAudioTypes)
         {
             this.selectedFilePaths = selectedFilePaths;
             this.selectedAudioTypes = selectedAudioTypes;

--- a/BusinessLogicLayer/Audio/AudioTypeMP3.cs
+++ b/BusinessLogicLayer/Audio/AudioTypeMP3.cs
@@ -4,9 +4,9 @@ using System.Text;
 
 namespace BusinessLogicLayer.Audio
 {
-    public class TypeMP3 : AudioType
+    public class AudioTypeMP3 : IAudioType
     {
-        public override string AddAudioFiletype(string filename)
+        public string AddAudioFiletype(string filename)
         {
             return filename += ".mp3";
         }

--- a/BusinessLogicLayer/Audio/AudioTypeWAV.cs
+++ b/BusinessLogicLayer/Audio/AudioTypeWAV.cs
@@ -4,9 +4,9 @@ using System.Text;
 
 namespace BusinessLogicLayer.Audio
 {
-    public class TypeWAV : AudioType
+    public class AudioTypeWAV : IAudioType
     {
-        public override string AddAudioFiletype(string filename)
+        public string AddAudioFiletype(string filename)
         {
             return filename += ".wav";
         }

--- a/BusinessLogicLayer/Audio/IAudioType.cs
+++ b/BusinessLogicLayer/Audio/IAudioType.cs
@@ -4,8 +4,8 @@ using System.Text;
 
 namespace BusinessLogicLayer.Audio
 {
-    public abstract class AudioType
+    public interface IAudioType
     {
-        public abstract string AddAudioFiletype(string filepath);
+        string AddAudioFiletype(string filepath);
     }
 }

--- a/BusinessLogicLayer/IFileHandling.cs
+++ b/BusinessLogicLayer/IFileHandling.cs
@@ -4,7 +4,7 @@ using System.Text;
 
 namespace BusinessLogicLayer
 {
-    public interface FileHandling
+    public interface IFileHandling
     {
         void ChangeFiletype();
 

--- a/MediaManager/MediaManager.cs
+++ b/MediaManager/MediaManager.cs
@@ -8,7 +8,7 @@ namespace MediaManager
 {
     public partial class MediaManager : Form
     {
-        List<AudioType> selectedAudioTypes = new List<AudioType>();
+        List<IAudioType> selectedAudioTypes = new List<IAudioType>();
         List<string> filePaths = new List<string>();
         List<string> fileNames = new List<string>();
 
@@ -69,11 +69,11 @@ namespace MediaManager
             {
                 if (filetype == "wav")
                 {
-                    selectedAudioTypes.Add(new TypeWAV());
+                    selectedAudioTypes.Add(new AudioTypeWAV());
                 }
                 else if (filetype == "mp3")
                 {
-                    selectedAudioTypes.Add(new TypeMP3());
+                    selectedAudioTypes.Add(new AudioTypeMP3());
                 }
                 AudioFileHandling audioFileHandling = new AudioFileHandling(filePaths, selectedAudioTypes);
                 audioFileHandling.ChangeFiletype();

--- a/MediaManagerTest/AudioLogicTest.cs
+++ b/MediaManagerTest/AudioLogicTest.cs
@@ -8,7 +8,7 @@ namespace MediaManagerTest
     public class AudioLogicTest
     {
         AudioFileHandling audioFileHandling;
-        private List<AudioType> selectedAudioTypes = new List<AudioType>();
+        private List<IAudioType> selectedAudioTypes = new List<IAudioType>();
         int audioAmountBeforeConversion;
         int audioAmountAfterConversion;
 
@@ -17,7 +17,7 @@ namespace MediaManagerTest
         {
             // arrange
             List<string> audioFiles = new List<string>();
-            selectedAudioTypes.Add(new TypeWAV());
+            selectedAudioTypes.Add(new AudioTypeWAV());
             List<string> selectedFilePaths = new List<string>() { @"C:\tmp\1.mp4", @"C:\tmp\2.mp4" };
             audioFileHandling = new AudioFileHandling(selectedFilePaths, selectedAudioTypes);
 
@@ -38,7 +38,7 @@ namespace MediaManagerTest
         {
             // arrange
             List<string> audioFiles = new List<string>();
-            selectedAudioTypes.Add(new TypeMP3());
+            selectedAudioTypes.Add(new AudioTypeMP3());
             List<string> selectedFilePaths = new List<string>() { "C:\tmp\test1.mp4", "C:\tmp\test2.mp4" };
             audioFileHandling = new AudioFileHandling(selectedFilePaths, selectedAudioTypes);
 


### PR DESCRIPTION
* Changed the class type from 'abstract' to 'interface'.
* Changed the naming convention of the "FileHandling" interface and
it's implementations..
* Overlooked these details during previous commits.